### PR TITLE
feat: add initial tf plan for deploying Charmed HPC on LXD

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{md,tf,yaml,yml}]
+indent_style = space
+ident_size = 2
+
+[justfile]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# TF specifc ignores
+
+.terraform
+.terraform.lock.hcl
+*.tfstate*
+
+# IDE specific ignores
+.idea
+.vscode

--- a/justfile
+++ b/justfile
@@ -1,0 +1,73 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bold := `tput bold`
+normal := `tput sgr0`
+
+[private]
+default:
+  @just help
+
+# initialize charmed hpc deployment plans
+init:
+  #!/usr/bin/env bash
+  for plan in plans/*/; do
+    echo "{{bold}}Initializing plan $(basename ${plan})...{{normal}}"
+    tofu -chdir=${plan} init
+  done
+
+# format charmed hpc deployment plans
+fmt:
+  tofu fmt -recursive
+
+# check that charmed hpc deployment plans are valid
+check: init
+  #!/usr/bin/env bash
+  tofu fmt -check -recursive
+  for plan in plans/*/; do
+    echo "{{bold}}Validating plan $(basename ${plan})...{{normal}}"
+    tofu -chdir=${plan} validate
+  done
+
+# clean charmed hpc project directory
+clean:
+  find . -name .terraform -type d | xargs rm -rf
+  find . -name .terraform.lock.hcl -type f | xargs rm -rf
+  find . -name "terraform.tfstate*" -type f | xargs rm -rf
+
+[private]
+_exists target:
+  #!/usr/bin/env bash
+  if [[ ! -d "plans/{{target}}" ]]; then
+    echo "{{bold}}{{target}}{{normal}} is not a valid Charmed HPC deployment plan"
+    exit 1
+  fi
+
+# deploy charmed hpc cluster using plan `target`
+deploy target: (_exists target)
+  #!/usr/bin/env bash
+  cd plans/{{target}}
+  tofu init
+  tofu plan
+  tofu apply -auto-approve
+
+# destroy charmed hpc cluster deployed using plan `target`
+destroy target: (_exists target)
+  #!/usr/bin/env bash
+  cd plans/{{target}}
+  tofu apply -destroy -auto-approve
+
+# show available recipes
+help:
+  @just --list --unsorted

--- a/plans/localhost/main.tf
+++ b/plans/localhost/main.tf
@@ -1,0 +1,153 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy a minimal Charmed HPC cloud on LXD
+
+provider "juju" {}
+
+resource "juju_model" "charmed-hpc" {
+  name = var.model
+}
+
+module "controller" {
+  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmctld/terraform"
+
+  model_name = var.model
+  app_name   = "contoller"
+  channel    = var.controller-channel
+  units      = var.controller-scale
+}
+
+module "compute" {
+  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmd/terraform"
+
+  model_name = var.model
+  app_name   = "compute"
+  channel    = var.compute-channel
+  units      = var.compute-scale
+}
+
+module "database" {
+  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmdbd/terraform"
+
+  model_name = var.model
+  app_name   = "database"
+  channel    = var.database-channel
+  units      = var.database-scale
+}
+
+module "rest-api" {
+  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmrestd/terraform"
+
+  model_name = var.model
+  app_name   = "rest-api"
+  channel    = var.rest-api-channel
+  units      = var.rest-api-scale
+}
+
+# FIXME: Source from upstream mysql operator once tf module is published.
+resource "juju_application" "mysql" {
+  name = "mysql"
+  model = var.model
+
+  charm {
+    name     = "mysql"
+    channel  = var.mysql-channel
+    revision = var.mysql-revision
+  }
+
+  units = var.mysql-scale
+}
+
+# FIXME: Source from upstream mysql-router operator once tf module is published.
+resource "juju_application" "database-mysql-router" {
+  name = "database-mysql-router"
+  model = var.model
+
+  charm {
+    name     = "mysql-router"
+    channel  = var.mysql-router-channel
+    revision = var.mysql-router-revision
+  }
+}
+
+resource "juju_integration" "compute-to-controller" {
+  model = var.model
+
+  application {
+    name     = module.compute.app_name
+    endpoint = module.compute.provides.slurmctld
+  }
+
+  application {
+    name     = module.controller.app_name
+    endpoint = module.controller.requires.slurmd
+  }
+}
+
+resource "juju_integration" "database-to-controller" {
+  model = var.model
+
+  application {
+    name     = module.database.app_name
+    endpoint = module.database.provides.slurmctld
+  }
+
+  application {
+    name     = module.controller.app_name
+    endpoint = module.controller.requires.slurmdbd
+  }
+}
+
+resource "juju_integration" "rest-api-to-controller" {
+  model = var.model
+
+  application {
+    name     = module.rest-api.app_name
+    endpoint = module.rest-api.provides.slurmctld
+  }
+
+  application {
+    name     = module.controller.app_name
+    endpoint = module.controller.requires.slurmrestd
+  }
+}
+
+resource "juju_integration" "database-to-mysql-router" {
+  model = var.model
+
+  application {
+    name     = module.database.app_name
+    endpoint = module.database.requires.database
+  }
+
+  application {
+    name     = juju_application.database-mysql-router.name
+    endpoint = "database"
+  }
+}
+
+resource "juju_integration" "mysql-router-to-mysql" {
+  model = var.model
+
+  application {
+    name     = juju_application.database-mysql-router.name
+    endpoint = "backend-database"
+  }
+
+  application {
+    name     = juju_application.mysql.name
+    endpoint = "database"
+  }
+}

--- a/plans/localhost/variables.tf
+++ b/plans/localhost/variables.tf
@@ -1,0 +1,97 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "model" {
+  description = "Name of Charmed HPC cluster"
+  type        = string
+  default     = "charmed-hpc"
+}
+
+variable "compute-channel" {
+  description = "Channel to deploy compute (slurmd) from."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "compute-scale" {
+  description = "Scale of compute application."
+  type        = number
+  default     = 1
+}
+
+variable "controller-channel" {
+  description = "Channel to deploy controller (slurmctld) from."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "controller-scale" {
+  description = "Scale of controller application"
+  type        = number
+  default     = 1
+}
+
+variable "database-channel" {
+  description = "Channel to deploy database (slurmdbd) from."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "database-scale" {
+  description = "Scale of database application."
+  type        = number
+  default     = 1
+}
+
+variable "mysql-channel" {
+  description = "Channel to deploy mysql from."
+  type        = string
+  default     = "8.0/stable"
+}
+
+variable "mysql-revision" {
+  description = "Revision of mysql to deploy from channel."
+  type        = number
+  default     = null
+}
+
+variable "mysql-scale" {
+  description = "Scale of mysql application"
+  type        = number
+  default     = 1
+}
+
+variable "mysql-router-channel" {
+  description = "Channel to deploy mysql-router from."
+  type        = string
+  default     = "dpe/beta"
+}
+
+variable "mysql-router-revision" {
+  description = "Revision of mysql-router to deploy from channel."
+  type        = number
+  default     = null
+}
+
+variable "rest-api-channel" {
+  description = "Channel to deploy REST API (slurmrestd) from."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "rest-api-scale" {
+  description = "Scale of REST API application."
+  type        = number
+  default     = 1
+}

--- a/plans/localhost/versions.tf
+++ b/plans/localhost/versions.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.13.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR contains an initial TF plan for deploying Charmed HPC on LXD. It pulls down the TF modules published to `slurm-charms` and uses the modules to set up Slurm on LXD. You can use the justfile to deploy Charmed HPC on LXD (assuming you already have a deployed Juju controller on LXD):

```shell
apt install just
sudo snap install opentofu --classic
just deploy localhost
```

I did notice some wonkyness with the Juju TF provider where deployments would randomly fail, but it would succeed the second time that I would run `just deploy localhost`. Future work is to add a README.md file and model how the file system and identity stacks will be set up on Azure.